### PR TITLE
ci: auto-generate ArtifactHub changelog from conventional commits

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -28,6 +28,8 @@ on:
         type: boolean
         default: false
 
+concurrency: chart_releaser
+
 jobs:
   bump:
     runs-on: ubuntu-24.04
@@ -153,6 +155,21 @@ jobs:
             sed -i "s/chromiumVersion: \"${old_chromium}\"/chromiumVersion: \"${new_chromium}\"/" charts/openclaw/values.yaml
             sed -i "s|zenika/alpine-chrome:${old_chromium}|zenika/alpine-chrome:${new_chromium}|g" charts/openclaw/Chart.yaml
             echo "Updated chromium: ${old_chromium} -> ${new_chromium}"
+          fi
+
+      - name: Update ArtifactHub changelog
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          changelog=""
+          if [ "${{ steps.check.outputs.openclaw_changed }}" = "true" ]; then
+            changelog="${changelog}- kind: changed\n  description: \"Bump OpenClaw to ${{ steps.get-version.outputs.version }}\"\n"
+          fi
+          if [ "${{ steps.check.outputs.chromium_changed }}" = "true" ]; then
+            changelog="${changelog}- kind: changed\n  description: \"Bump Chromium to ${{ inputs.chromium_version }}\"\n"
+          fi
+          if [ -n "$changelog" ]; then
+            printf "%b" "$changelog" > /tmp/changelog.yaml
+            yq -i '.annotations["artifacthub.io/changes"] = load_str("/tmp/changelog.yaml")' charts/openclaw/Chart.yaml
           fi
 
       - name: Install helm-docs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,49 @@ jobs:
             echo "bumped=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate ArtifactHub changelog
+        run: |
+          # Find the latest existing release tag
+          last_tag=$(git tag --sort=-version:refname | grep '^openclaw-' | head -1)
+          if [ -z "$last_tag" ]; then
+            echo "No previous tag found, using all commits"
+            range="HEAD"
+          else
+            echo "Generating changelog since $last_tag"
+            range="${last_tag}..HEAD"
+          fi
+
+          # Parse conventional commits into ArtifactHub changelog YAML
+          changelog=""
+          while IFS= read -r msg; do
+            [ -z "$msg" ] && continue
+            # Skip bot commits
+            case "$msg" in "chore: update chart version"*|"chore: regenerate"*) continue;; esac
+            # Map conventional commit type to ArtifactHub kind
+            kind="changed"
+            case "$msg" in
+              feat:*|feat\(*) kind="added" ;;
+              fix:*|fix\(*)   kind="fixed" ;;
+            esac
+            # Strip type prefix for description
+            desc=$(echo "$msg" | sed 's/^[a-z]*\([^)]*\)\?: *//')
+            desc="$(echo "$desc" | cut -c1 | tr '[:lower:]' '[:upper:]')$(echo "$desc" | cut -c2-)"
+            # Escape characters that would break YAML double-quoted strings
+            desc="${desc//\\/\\\\}"
+            desc="${desc//\"/\\\"}"
+            changelog="${changelog}- kind: ${kind}\n  description: \"${desc}\"\n"
+          done < <(git log --format='%s' "$range" -- charts/)
+
+          if [ -n "$changelog" ]; then
+            # Write changelog to temp file and update Chart.yaml
+            printf "%b" "$changelog" > /tmp/changelog.yaml
+            yq -i '.annotations["artifacthub.io/changes"] = load_str("/tmp/changelog.yaml")' charts/openclaw/Chart.yaml
+            echo "Updated ArtifactHub changelog:"
+            cat /tmp/changelog.yaml
+          else
+            echo "No chart-related commits found, keeping existing changelog"
+          fi
+
       - name: Regenerate docs
         run: |
           helm-docs --chart-search-root=charts


### PR DESCRIPTION
The ArtifactHub changelog was static — every release showed the same entries regardless of what actually changed. This adds dynamic changelog generation to both release paths.

**release.yaml** (PR merges to main):
- Parses conventional commits since the last `openclaw-*` tag
- Maps `feat:` → added, `fix:` → fixed, everything else → changed
- Strips commit type prefix and capitalizes the description
- Skips bot commits (`chore: update chart version*`, `chore: regenerate*`)
- Escapes double quotes and backslashes in commit messages to produce valid YAML

**bump-version.yaml** (scheduled/manual version bumps):
- Generates changelog entries based on what was actually bumped (e.g. "Bump OpenClaw to 2026.2.8", "Bump Chromium to 125")
- Shares the same `chart_releaser` concurrency group with release.yaml to prevent race conditions

Both workflows write changelog entries without leading indentation and use `yq load_str()` to set the `artifacthub.io/changes` annotation, letting yq handle the YAML block scalar formatting.