### PR TITLE
fix: remove continue-on-error from schema generation and add .helmignore

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -186,7 +186,6 @@ jobs:
 
       - name: Generate values schema
         if: steps.check.outputs.skip != 'true'
-        continue-on-error: true
         uses: losisin/helm-values-schema-json-action@v2
         with:
           values: charts/openclaw/values.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,6 @@ jobs:
           helm-docs --chart-search-root=charts
 
       - name: Generate values schema
-        continue-on-error: true
         uses: losisin/helm-values-schema-json-action@v2
         with:
           values: charts/openclaw/values.yaml

--- a/charts/openclaw/.helmignore
+++ b/charts/openclaw/.helmignore
@@ -1,0 +1,22 @@
+# VCS
+.git/
+.gitignore
+
+# Dev/build files
+README.md.gotmpl
+.schema.yaml
+
+# CI
+.github/
+ct.yaml
+
+# Editor
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Schema generation in release and bump-version workflows was silently swallowing failures via `continue-on-error: true`, which could allow broken or stale `values.schema.json` to ship unnoticed.

Also adds a `.helmignore` to exclude dev-only files (`README.md.gotmpl`, `.schema.yaml`, editor/OS artifacts) from the packaged chart, reducing artifact size.

Changes:
- Remove `continue-on-error: true` from schema generation step in `release.yaml`
- Remove `continue-on-error: true` from schema generation step in `bump-version.yaml`
- Add `charts/openclaw/.helmignore`