### PR TITLE
feature: add Homebrew installation with configurable packages

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -73,3 +73,12 @@ jobs:
       - name: Helm template validation
         run: |
           helm template test charts/openclaw --debug > /dev/null
+
+      - name: Set up yq
+        run: |
+          curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.52.5/yq_linux_amd64 -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
+      - name: Snapshot tests
+        run: |
+          bash tests/test.sh

--- a/charts/openclaw/README.md
+++ b/charts/openclaw/README.md
@@ -150,6 +150,7 @@ All values are nested under `app-template:`. See [values.yaml](values.yaml) for 
 | app-template.configMaps.config.data.bash_aliases | string | `"alias openclaw='node /app/dist/index.js'\n"` |  |
 | app-template.configMaps.config.enabled | bool | `true` |  |
 | app-template.configMaps.scripts.data."init-config.sh" | string | `"log() { echo \"[$(date -Iseconds)] [init-config] $*\"; }\n\nlog \"Starting config initialization\"\nmkdir -p /home/node/.openclaw\nCONFIG_MODE=\"${CONFIG_MODE:-merge}\"\n\nif [ \"$CONFIG_MODE\" = \"merge\" ] && [ -f /home/node/.openclaw/openclaw.json ]; then\n  log \"Mode: merge - merging Helm config with existing config\"\n  if node -e \"\n    const fs = require('fs');\n    // Strip JSON5 single-line comments while preserving // inside strings (e.g. URLs)\n    const stripComments = (s) => {\n      let r = '', q = false, i = 0;\n      while (i < s.length) {\n        if (q) {\n          if (s[i] === '\\\\\\\\') { r += s[i] + s[i+1]; i += 2; continue; }\n          if (s[i] === '\\\"') q = false;\n          r += s[i++];\n        } else if (s[i] === '\\\"') {\n          q = true; r += s[i++];\n        } else if (s[i] === '/' && s[i+1] === '/') {\n          while (i < s.length && s[i] !== '\\n') i++;\n        } else { r += s[i++]; }\n      }\n      return r;\n    };\n    let existing;\n    try {\n      existing = JSON.parse(stripComments(fs.readFileSync('/home/node/.openclaw/openclaw.json', 'utf8')));\n    } catch (e) {\n      console.error('[init-config] Warning: existing config is not valid JSON, will overwrite');\n      process.exit(1);\n    }\n    const helm = JSON.parse(stripComments(fs.readFileSync('/config/openclaw.json', 'utf8')));\n    const deepMerge = (target, source) => {\n      for (const key of Object.keys(source)) {\n        if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {\n          target[key] = target[key] || {};\n          deepMerge(target[key], source[key]);\n        } else {\n          target[key] = source[key];\n        }\n      }\n      return target;\n    };\n    const merged = deepMerge(existing, helm);\n    fs.writeFileSync('/home/node/.openclaw/openclaw.json', JSON.stringify(merged, null, 2));\n  \"; then\n    log \"Config merged successfully\"\n  else\n    log \"WARNING: Merge failed (existing config may not be valid JSON), falling back to overwrite\"\n    cp /config/openclaw.json /home/node/.openclaw/openclaw.json\n  fi\nelse\n  if [ ! -f /home/node/.openclaw/openclaw.json ]; then\n    log \"Fresh install - writing initial config\"\n  else\n    log \"Mode: overwrite - replacing config with Helm values\"\n  fi\n  cp /config/openclaw.json /home/node/.openclaw/openclaw.json\nfi\nlog \"Config initialization complete\"\n"` |  |
+| app-template.configMaps.scripts.data."init-homebrew.sh" | string | `"log() { echo \"[$(date -Iseconds)] [init-homebrew] $*\"; }\n\nif [ \"${HOMEBREW_ENABLED:-false}\" != \"true\" ]; then\n  log \"Homebrew disabled, skipping\"\n  exit 0\nfi\n\nlog \"Starting Homebrew initialization\"\n\nHOMEBREW_PREFIX=/home/node/.openclaw/homebrew\nexport HOMEBREW_NO_AUTO_UPDATE=1\nexport HOMEBREW_NO_ANALYTICS=1\nexport HOMEBREW_NO_ENV_HINTS=1\n\nif [ ! -d \"$HOMEBREW_PREFIX\" ]; then\n  log \"Installing Homebrew...\"\n  git clone --depth=1 https://github.com/Homebrew/brew \"$HOMEBREW_PREFIX\"\nelse\n  log \"Homebrew already installed, skipping clone\"\nfi\n\nexport PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:$PATH\"\n\nif [ -n \"${HOMEBREW_PACKAGES:-}\" ]; then\n  log \"Installing packages: $HOMEBREW_PACKAGES\"\n  # shellcheck disable=SC2086\n  brew install $HOMEBREW_PACKAGES\nelse\n  log \"No packages to install\"\nfi\n\nlog \"Homebrew initialization complete\"\n"` |  |
 | app-template.configMaps.scripts.data."init-skills.sh" | string | `"log() { echo \"[$(date -Iseconds)] [init-skills] $*\"; }\n\nlog \"Starting skills initialization\"\n\n# ============================================================\n# Runtime Dependencies\n# ============================================================\n# Some skills require additional runtimes (Python, Go, etc.)\n# Install them here so they persist across pod restarts.\n#\n# Example: Install uv (Python package manager) for Python skills\n# mkdir -p /home/node/.openclaw/bin\n# if [ ! -f /home/node/.openclaw/bin/uv ]; then\n#   log \"Installing uv...\"\n#   curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/home/node/.openclaw/bin sh\n# fi\n#\n# Example: Install pnpm and packages for interfaces (e.g., MS Teams)\n# The read-only filesystem and non-root UID prevent writing to default\n# pnpm paths (/usr/local/lib/node_modules, ~/.local/share/pnpm, etc.).\n# Redirect PNPM_HOME to the PVC so the binary persists across restarts.\n# The init container's HOME=/tmp ensures pnpm's cache, state, and config\n# writes land on /tmp (writable emptyDir). The store goes on the PVC so\n# hardlinks work (same filesystem as node_modules) and persist.\n# PNPM_HOME=/home/node/.openclaw/pnpm\n# mkdir -p \"$PNPM_HOME\"\n# if [ ! -f \"$PNPM_HOME/pnpm\" ]; then\n#   log \"Installing pnpm...\"\n#   curl -fsSL https://get.pnpm.io/install.sh | env PNPM_HOME=\"$PNPM_HOME\" SHELL=/bin/sh sh -\n# fi\n# export PATH=\"$PNPM_HOME:$PATH\"\n# log \"Installing interface dependencies...\"\n# cd /home/node/.openclaw\n# pnpm install <your-package> --store-dir /home/node/.openclaw/.pnpm-store\n\n# ============================================================\n# Skill Installation\n# ============================================================\n# Installs skills listed in SKILLS_TO_INSTALL (set via the top-level skills: [] value).\n# Set skills: [] in your values to skip skill installation entirely.\nmkdir -p /home/node/.openclaw/workspace/skills\ncd /home/node/.openclaw/workspace\ninstall_skill() {\n  skill=\"$1\"\n  SKILL_NAME=\"$(basename \"$skill\")\"\n  if [ -z \"$skill\" ]; then\n    return 0\n  fi\n  if [ -d \"skills/$SKILL_NAME\" ]; then\n    log \"Skill already installed: $skill\"\n    return 0\n  fi\n  log \"Installing skill: $skill\"\n  attempts=6\n  delay=5\n  for i in $(seq 1 \"$attempts\"); do\n    if npx -y clawhub install \"$skill\" --no-input; then\n      log \"Installed skill: $skill\"\n      return 0\n    fi\n    # Add a little jitter so concurrent pods don't retry in lockstep.\n    jitter=$((RANDOM % 5))\n    if [ \"$i\" -lt \"$attempts\" ]; then\n      log \"WARNING: Failed to install skill: $skill (attempt $i/$attempts). Retrying in $((delay + jitter))s...\"\n      sleep $((delay + jitter))\n      delay=$((delay * 2))\n    fi\n  done\n  log \"WARNING: Failed to install skill after $attempts attempts: $skill\"\n  return 1\n}\nfor skill in $SKILLS_TO_INSTALL; do\n  install_skill \"$skill\" || true\ndone\nlog \"Skills initialization complete\"\n"` |  |
 | app-template.configMaps.scripts.enabled | bool | `true` |  |
 | app-template.configMode | string | `"merge"` | Config mode: `merge` preserves runtime changes, `overwrite` for strict GitOps |
@@ -172,6 +173,18 @@ All values are nested under `app-template:`. See [values.yaml](values.yaml) for 
 | app-template.controllers.main.initContainers.init-config.securityContext.runAsGroup | int | `1000` |  |
 | app-template.controllers.main.initContainers.init-config.securityContext.runAsNonRoot | bool | `true` |  |
 | app-template.controllers.main.initContainers.init-config.securityContext.runAsUser | int | `1000` |  |
+| app-template.controllers.main.initContainers.init-homebrew.command | list | `["sh","/scripts/init-homebrew.sh"]` | Init-homebrew startup script |
+| app-template.controllers.main.initContainers.init-homebrew.env.HOME | string | `"/tmp"` |  |
+| app-template.controllers.main.initContainers.init-homebrew.env.HOMEBREW_ENABLED | string | `"{{ .Values.homebrew.enabled }}"` |  |
+| app-template.controllers.main.initContainers.init-homebrew.env.HOMEBREW_PACKAGES | string | `"{{ .Values.homebrew.packages | join \" \" }}"` |  |
+| app-template.controllers.main.initContainers.init-homebrew.image.repository | string | `"ghcr.io/openclaw/openclaw"` |  |
+| app-template.controllers.main.initContainers.init-homebrew.image.tag | string | `"{{ .Values.openclawVersion }}"` |  |
+| app-template.controllers.main.initContainers.init-homebrew.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| app-template.controllers.main.initContainers.init-homebrew.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| app-template.controllers.main.initContainers.init-homebrew.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| app-template.controllers.main.initContainers.init-homebrew.securityContext.runAsGroup | int | `1000` |  |
+| app-template.controllers.main.initContainers.init-homebrew.securityContext.runAsNonRoot | bool | `true` |  |
+| app-template.controllers.main.initContainers.init-homebrew.securityContext.runAsUser | int | `1000` |  |
 | app-template.controllers.main.initContainers.init-skills.command | list | `["sh","/scripts/init-skills.sh"]` | Init-skills startup script |
 | app-template.controllers.main.initContainers.init-skills.env.HOME | string | `"/tmp"` |  |
 | app-template.controllers.main.initContainers.init-skills.env.NPM_CONFIG_CACHE | string | `"/tmp/.npm"` |  |
@@ -187,6 +200,8 @@ All values are nested under `app-template:`. See [values.yaml](values.yaml) for 
 | app-template.controllers.main.replicas | int | `1` | Number of replicas (must be 1, OpenClaw doesn't support horizontal scaling) |
 | app-template.controllers.main.strategy | string | `"Recreate"` | Deployment strategy |
 | app-template.defaultPodOptions.securityContext | object | `{"fsGroup":1000,"fsGroupChangePolicy":"OnRootMismatch"}` | Pod security context |
+| app-template.homebrew.enabled | bool | `false` | Enable the Homebrew init container |
+| app-template.homebrew.packages | list | `[]` | Homebrew packages to install (e.g. `[gh, gogcli]`) |
 | app-template.ingress.main.enabled | bool | `false` | Enable ingress resource creation |
 | app-template.networkpolicies.main.controller | string | `"main"` |  |
 | app-template.networkpolicies.main.enabled | bool | `false` | Enable network policy (default deny-all with explicit allow rules) |
@@ -221,6 +236,7 @@ All values are nested under `app-template:`. See [values.yaml](values.yaml) for 
 | app-template.persistence.config.type | string | `"configMap"` |  |
 | app-template.persistence.data.accessMode | string | `"ReadWriteOnce"` | PVC access mode |
 | app-template.persistence.data.advancedMounts.main.init-config[0].path | string | `"/home/node/.openclaw"` |  |
+| app-template.persistence.data.advancedMounts.main.init-homebrew[0].path | string | `"/home/node/.openclaw"` |  |
 | app-template.persistence.data.advancedMounts.main.init-skills[0].path | string | `"/home/node/.openclaw"` |  |
 | app-template.persistence.data.advancedMounts.main.main[0].path | string | `"/home/node/.openclaw"` |  |
 | app-template.persistence.data.enabled | bool | `true` |  |
@@ -228,6 +244,8 @@ All values are nested under `app-template:`. See [values.yaml](values.yaml) for 
 | app-template.persistence.data.type | string | `"persistentVolumeClaim"` |  |
 | app-template.persistence.scripts.advancedMounts.main.init-config[0].path | string | `"/scripts"` |  |
 | app-template.persistence.scripts.advancedMounts.main.init-config[0].readOnly | bool | `true` |  |
+| app-template.persistence.scripts.advancedMounts.main.init-homebrew[0].path | string | `"/scripts"` |  |
+| app-template.persistence.scripts.advancedMounts.main.init-homebrew[0].readOnly | bool | `true` |  |
 | app-template.persistence.scripts.advancedMounts.main.init-skills[0].path | string | `"/scripts"` |  |
 | app-template.persistence.scripts.advancedMounts.main.init-skills[0].readOnly | bool | `true` |  |
 | app-template.persistence.scripts.enabled | bool | `true` |  |
@@ -235,6 +253,7 @@ All values are nested under `app-template:`. See [values.yaml](values.yaml) for 
 | app-template.persistence.scripts.type | string | `"configMap"` |  |
 | app-template.persistence.tmp.advancedMounts.main.chromium[0].path | string | `"/tmp"` |  |
 | app-template.persistence.tmp.advancedMounts.main.init-config[0].path | string | `"/tmp"` |  |
+| app-template.persistence.tmp.advancedMounts.main.init-homebrew[0].path | string | `"/tmp"` |  |
 | app-template.persistence.tmp.advancedMounts.main.init-skills[0].path | string | `"/tmp"` |  |
 | app-template.persistence.tmp.advancedMounts.main.main[0].path | string | `"/tmp"` |  |
 | app-template.persistence.tmp.enabled | bool | `true` |  |
@@ -405,6 +424,33 @@ app-template:
                 fi
               done
 ```
+
+### Homebrew
+
+The `init-homebrew` init container installs [Homebrew](https://brew.sh) into the data PVC and can also install the listed packages. It is disabled by default and runs before `init-skills` so tools installed with homebrew are available to skills.
+
+```yaml
+app-template:
+  homebrew:
+    enabled: true
+    packages:
+      - gh
+      - gogcli
+```
+
+After enabling, expose the Homebrew bin dirs to the main container:
+
+```yaml
+app-template:
+  controllers:
+    main:
+      containers:
+        main:
+          env:
+            PATH: /home/node/.openclaw/homebrew/bin:/home/node/.openclaw/homebrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+```
+
+The installation is idempotent: subsequent pod restarts skip steps that are already complete (Homebrew clone and already-installed packages). Beware that Homebrew and its packages are not updated automatically. Also note that openclaw can use it to install packages at runtime, if you do not want this keep the Homebrew container disabled.
 
 ### Runtime Dependencies
 

--- a/charts/openclaw/README.md
+++ b/charts/openclaw/README.md
@@ -672,6 +672,26 @@ helm dependency update charts/openclaw
 helm template test charts/openclaw --debug
 ```
 
+### Snapshot tests
+
+`tests/test.sh` renders the chart for a set of scenarios and diffs the output against committed snapshots in `tests/snapshots/`. The test fails if the rendered output differs from the snapshot, catching unintended breaking changes to the default output.
+
+Run the tests:
+
+```bash
+bash tests/test.sh
+```
+
+When a change to the chart output is intentional, update the snapshots and commit them:
+
+```bash
+bash tests/test.sh --update
+git add tests/snapshots
+git commit -m "chore: update helm snapshots"
+```
+
+Snapshot tests also run in CI as part of the `validate` job in the lint workflow.
+
 ---
 
 ## Dependencies

--- a/charts/openclaw/README.md.gotmpl
+++ b/charts/openclaw/README.md.gotmpl
@@ -553,6 +553,26 @@ helm dependency update charts/{{ .Name }}
 helm template test charts/{{ .Name }} --debug
 ```
 
+### Snapshot tests
+
+`tests/test.sh` renders the chart for a set of scenarios and diffs the output against committed snapshots in `tests/snapshots/`. The test fails if the rendered output differs from the snapshot, catching unintended breaking changes to the default output.
+
+Run the tests:
+
+```bash
+bash tests/test.sh
+```
+
+When a change to the chart output is intentional, update the snapshots and commit them:
+
+```bash
+bash tests/test.sh --update
+git add tests/snapshots
+git commit -m "chore: update helm snapshots"
+```
+
+Snapshot tests also run in CI as part of the `validate` job in the lint workflow.
+
 ---
 
 ## Dependencies

--- a/charts/openclaw/README.md.gotmpl
+++ b/charts/openclaw/README.md.gotmpl
@@ -306,6 +306,33 @@ app-template:
               done
 ```
 
+### Homebrew
+
+The `init-homebrew` init container installs [Homebrew](https://brew.sh) into the data PVC and can also install the listed packages. It is disabled by default and runs before `init-skills` so tools installed with homebrew are available to skills.
+
+```yaml
+app-template:
+  homebrew:
+    enabled: true
+    packages:
+      - gh
+      - gogcli
+```
+
+After enabling, expose the Homebrew bin dirs to the main container:
+
+```yaml
+app-template:
+  controllers:
+    main:
+      containers:
+        main:
+          env:
+            PATH: /home/node/.{{ .Name }}/homebrew/bin:/home/node/.{{ .Name }}/homebrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+```
+
+The installation is idempotent: subsequent pod restarts skip steps that are already complete (Homebrew clone and already-installed packages). Beware that Homebrew and its packages are not updated automatically. Also note that openclaw can use it to install packages at runtime, if you do not want this keep the Homebrew container disabled.
+
 ### Runtime Dependencies
 
 Some features (interfaces, skills) require additional runtimes or packages not included in the base image. The `init-skills` init container handles this -- install extra tooling to the PVC at `/home/node/.{{ .Name }}` so it persists across pod restarts and is available at runtime.

--- a/charts/openclaw/values.schema.json
+++ b/charts/openclaw/values.schema.json
@@ -46,6 +46,9 @@
                                         "init-config.sh": {
                                             "type": "string"
                                         },
+                                        "init-homebrew.sh": {
+                                            "type": "string"
+                                        },
                                         "init-skills.sh": {
                                             "type": "string"
                                         }
@@ -622,6 +625,75 @@
                                                 }
                                             }
                                         },
+                                        "init-homebrew": {
+                                            "type": "object",
+                                            "properties": {
+                                                "command": {
+                                                    "description": "Init-homebrew startup script",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "env": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "HOME": {
+                                                            "type": "string"
+                                                        },
+                                                        "HOMEBREW_ENABLED": {
+                                                            "type": "string"
+                                                        },
+                                                        "HOMEBREW_PACKAGES": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
+                                                "image": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "repository": {
+                                                            "default": "ghcr.io/openclaw/openclaw",
+                                                            "type": "string"
+                                                        },
+                                                        "tag": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                },
+                                                "securityContext": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "allowPrivilegeEscalation": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "capabilities": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "drop": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "readOnlyRootFilesystem": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "runAsGroup": {
+                                                            "type": "integer"
+                                                        },
+                                                        "runAsNonRoot": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "runAsUser": {
+                                                            "type": "integer"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
                                         "init-skills": {
                                             "type": "object",
                                             "properties": {
@@ -735,6 +807,21 @@
                             }
                         }
                     }
+                },
+                "homebrew": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable the Homebrew init container",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "packages": {
+                            "description": "Homebrew packages to install (e.g. `[gh, gogcli]`)",
+                            "type": "array"
+                        }
+                    },
+                    "additionalProperties": false
                 },
                 "ingress": {
                     "type": "object",
@@ -1013,6 +1100,17 @@
                                                         }
                                                     }
                                                 },
+                                                "init-homebrew": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "path": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                },
                                                 "init-skills": {
                                                     "type": "array",
                                                     "items": {
@@ -1077,6 +1175,20 @@
                                                         }
                                                     }
                                                 },
+                                                "init-homebrew": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "path": {
+                                                                "type": "string"
+                                                            },
+                                                            "readOnly": {
+                                                                "type": "boolean"
+                                                            }
+                                                        }
+                                                    }
+                                                },
                                                 "init-skills": {
                                                     "type": "array",
                                                     "items": {
@@ -1127,6 +1239,17 @@
                                                     }
                                                 },
                                                 "init-config": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "path": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "init-homebrew": {
                                                     "type": "array",
                                                     "items": {
                                                         "type": "object",

--- a/charts/openclaw/values.yaml
+++ b/charts/openclaw/values.yaml
@@ -21,6 +21,37 @@ app-template:
     - weather
     - gog
 
+  # ============================================================
+  # Homebrew
+  # ============================================================
+  # When enabled, an init container clones Homebrew into the data PVC
+  # (/home/node/.openclaw/homebrew) and installs the listed packages.
+  # The installation is idempotent: subsequent pod restarts skip steps
+  # that are already complete.
+  #
+  # After enabling, add the Homebrew bin dirs to the main container PATH so
+  # that installed tools are available at runtime:
+  #
+  #   app-template:
+  #     controllers:
+  #       main:
+  #         containers:
+  #           main:
+  #             env:
+  #               PATH: >-
+  #                 /home/node/.openclaw/homebrew/bin:
+  #                 /home/node/.openclaw/homebrew/sbin:
+  #                 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  #
+  # @schema additionalProperties:false
+  homebrew:
+    # @schema type:boolean;default:false
+    # -- Enable the Homebrew init container
+    enabled: false
+    # @schema type:array
+    # -- Homebrew packages to install (e.g. `[gh, gogcli]`)
+    packages: []
+
   defaultPodOptions:
     # -- Pod security context
     securityContext:
@@ -53,6 +84,34 @@ app-template:
             - /scripts/init-config.sh
           env:
             CONFIG_MODE: "{{ .Values.configMode | default \"merge\" }}"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+
+        # Install Homebrew and packages into the data PVC (idempotent, no-op when disabled).
+        # Runs before init-skills so that Homebrew-installed tools are available to skills.
+        init-homebrew:
+          image:
+            # @schema type:string;default:ghcr.io/openclaw/openclaw
+            repository: ghcr.io/openclaw/openclaw
+            # @schema type:string
+            tag: "{{ .Values.openclawVersion }}"
+          # -- Init-homebrew startup script
+          command:
+            - sh
+            - /scripts/init-homebrew.sh
+          env:
+            # @schema type:string
+            HOMEBREW_ENABLED: "{{ .Values.homebrew.enabled }}"
+            # @schema type:string
+            HOMEBREW_PACKAGES: '{{ .Values.homebrew.packages | join " " }}'
+            HOME: /tmp
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -121,7 +180,7 @@ app-template:
           env: {}
           # Example: Add runtime dependency paths for skills and extra runtimes
           # env:
-          #   PATH: /home/node/.openclaw/pnpm:/home/node/.openclaw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          #   PATH: /home/node/.openclaw/pnpm:/home/node/.openclaw/bin:/home/node/.openclaw/homebrew/bin:/home/node/.openclaw/homebrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           #   PNPM_HOME: /home/node/.openclaw/pnpm
           #   PNPM_STORE_DIR: /home/node/.openclaw/.pnpm-store
           #   # For internal CA trust (Python requests library)
@@ -358,6 +417,40 @@ app-template:
           fi
           log "Config initialization complete"
 
+        init-homebrew.sh: |
+          log() { echo "[$(date -Iseconds)] [init-homebrew] $*"; }
+
+          if [ "${HOMEBREW_ENABLED:-false}" != "true" ]; then
+            log "Homebrew disabled, skipping"
+            exit 0
+          fi
+
+          log "Starting Homebrew initialization"
+
+          HOMEBREW_PREFIX=/home/node/.openclaw/homebrew
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          export HOMEBREW_NO_ANALYTICS=1
+          export HOMEBREW_NO_ENV_HINTS=1
+
+          if [ ! -d "$HOMEBREW_PREFIX" ]; then
+            log "Installing Homebrew..."
+            git clone --depth=1 https://github.com/Homebrew/brew "$HOMEBREW_PREFIX"
+          else
+            log "Homebrew already installed, skipping clone"
+          fi
+
+          export PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:$PATH"
+
+          if [ -n "${HOMEBREW_PACKAGES:-}" ]; then
+            log "Installing packages: $HOMEBREW_PACKAGES"
+            # shellcheck disable=SC2086
+            brew install $HOMEBREW_PACKAGES
+          else
+            log "No packages to install"
+          fi
+
+          log "Homebrew initialization complete"
+
         init-skills.sh: |
           log() { echo "[$(date -Iseconds)] [init-skills] $*"; }
 
@@ -592,6 +685,9 @@ app-template:
           init-config:
             - path: /scripts
               readOnly: true
+          init-homebrew:
+            - path: /scripts
+              readOnly: true
           init-skills:
             - path: /scripts
               readOnly: true
@@ -638,6 +734,8 @@ app-template:
         main:
           init-config:
             - path: /home/node/.openclaw
+          init-homebrew:
+            - path: /home/node/.openclaw
           init-skills:
             - path: /home/node/.openclaw
           main:
@@ -652,6 +750,8 @@ app-template:
       advancedMounts:
         main:
           init-config:
+            - path: /tmp
+          init-homebrew:
             - path: /tmp
           init-skills:
             - path: /tmp

--- a/tests/snapshots/default.yaml
+++ b/tests/snapshots/default.yaml
@@ -1,0 +1,491 @@
+
+---
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+data:
+  bash_aliases: |
+    alias openclaw='node /app/dist/index.js'
+  openclaw.json: "{\n  // Gateway configuration\n  \"gateway\": {\n    \"port\": 18789,\n    \"mode\": \"local\",\n    // IMPORTANT: trustedProxies uses exact IP matching only\n    // - CIDR notation is NOT supported - list each proxy IP individually\n    // - IPv6 exact addresses may work but are untested\n    // - Recommend single-stack IPv4 deployments for simplicity\n    \"trustedProxies\": [\"10.0.0.1\"]\n  },\n\n  // Browser configuration (Chromium sidecar)\n  \"browser\": {\n    \"enabled\": true,\n    \"defaultProfile\": \"default\",\n    \"profiles\": {\n      \"default\": {\n        \"cdpUrl\": \"http://localhost:9222\",\n        \"color\": \"#4285F4\"\n      }\n    }\n  },\n\n  // Agent configuration\n  \"agents\": {\n    \"defaults\": {\n      \"workspace\": \"/home/node/.openclaw/workspace\",\n      \"model\": {\n        // Uses ANTHROPIC_API_KEY from environment\n        \"primary\": \"anthropic/claude-opus-4-6\"\n      },\n      \"userTimezone\": \"UTC\",\n      \"timeoutSeconds\": 600,\n      \"maxConcurrent\": 1\n    },\n    \"list\": [\n      {\n        \"id\": \"main\",\n        \"default\": true,\n        \"identity\": {\n          \"name\": \"OpenClaw\",\n          \"emoji\": \"\U0001F99E\"\n        }\n      }\n    ]\n  },\n\n  // Session management\n  \"session\": {\n    \"scope\": \"per-sender\",\n    \"store\": \"/home/node/.openclaw/sessions\",\n    \"reset\": {\n      \"mode\": \"idle\",\n      \"idleMinutes\": 60\n    }\n  },\n\n  // Logging\n  \"logging\": {\n    \"level\": \"info\",\n    \"consoleLevel\": \"info\",\n    \"consoleStyle\": \"compact\",\n    \"redactSensitive\": \"tools\"\n  },\n\n  // Tools configuration\n  \"tools\": {\n    \"profile\": \"full\",\n    \"web\": {\n      \"search\": {\n        \"enabled\": false\n      },\n      \"fetch\": {\n        \"enabled\": true\n      }\n    }\n  }\n\n  // Channel configuration can be added here:\n  // \"channels\": {\n  //   \"telegram\": {\n  //     \"botToken\": \"${TELEGRAM_BOT_TOKEN}\",\n  //     \"enabled\": true\n  //   },\n  //   \"discord\": {\n  //     \"token\": \"${DISCORD_BOT_TOKEN}\"\n  //   },\n  //   \"slack\": {\n  //     \"botToken\": \"${SLACK_BOT_TOKEN}\",\n  //     \"appToken\": \"${SLACK_APP_TOKEN}\"\n  //   }\n  // }\n}\n"
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-scripts
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+data:
+  init-config.sh: |
+    log() { echo "[$(date -Iseconds)] [init-config] $*"; }
+
+    log "Starting config initialization"
+    mkdir -p /home/node/.openclaw
+    CONFIG_MODE="${CONFIG_MODE:-merge}"
+
+    if [ "$CONFIG_MODE" = "merge" ] && [ -f /home/node/.openclaw/openclaw.json ]; then
+      log "Mode: merge - merging Helm config with existing config"
+      if node -e "
+        const fs = require('fs');
+        // Strip JSON5 single-line comments while preserving // inside strings (e.g. URLs)
+        const stripComments = (s) => {
+          let r = '', q = false, i = 0;
+          while (i < s.length) {
+            if (q) {
+              if (s[i] === '\\\\') { r += s[i] + s[i+1]; i += 2; continue; }
+              if (s[i] === '\"') q = false;
+              r += s[i++];
+            } else if (s[i] === '\"') {
+              q = true; r += s[i++];
+            } else if (s[i] === '/' && s[i+1] === '/') {
+              while (i < s.length && s[i] !== '\n') i++;
+            } else { r += s[i++]; }
+          }
+          return r;
+        };
+        let existing;
+        try {
+          existing = JSON.parse(stripComments(fs.readFileSync('/home/node/.openclaw/openclaw.json', 'utf8')));
+        } catch (e) {
+          console.error('[init-config] Warning: existing config is not valid JSON, will overwrite');
+          process.exit(1);
+        }
+        const helm = JSON.parse(stripComments(fs.readFileSync('/config/openclaw.json', 'utf8')));
+        const deepMerge = (target, source) => {
+          for (const key of Object.keys(source)) {
+            if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+              target[key] = target[key] || {};
+              deepMerge(target[key], source[key]);
+            } else {
+              target[key] = source[key];
+            }
+          }
+          return target;
+        };
+        const merged = deepMerge(existing, helm);
+        fs.writeFileSync('/home/node/.openclaw/openclaw.json', JSON.stringify(merged, null, 2));
+      "; then
+        log "Config merged successfully"
+      else
+        log "WARNING: Merge failed (existing config may not be valid JSON), falling back to overwrite"
+        cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+      fi
+    else
+      if [ ! -f /home/node/.openclaw/openclaw.json ]; then
+        log "Fresh install - writing initial config"
+      else
+        log "Mode: overwrite - replacing config with Helm values"
+      fi
+      cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+    fi
+    log "Config initialization complete"
+  init-homebrew.sh: |
+    log() { echo "[$(date -Iseconds)] [init-homebrew] $*"; }
+
+    if [ "${HOMEBREW_ENABLED:-false}" != "true" ]; then
+      log "Homebrew disabled, skipping"
+      exit 0
+    fi
+
+    log "Starting Homebrew initialization"
+
+    HOMEBREW_PREFIX=/home/node/.openclaw/homebrew
+    export HOMEBREW_NO_AUTO_UPDATE=1
+    export HOMEBREW_NO_ANALYTICS=1
+    export HOMEBREW_NO_ENV_HINTS=1
+
+    if [ ! -d "$HOMEBREW_PREFIX" ]; then
+      log "Installing Homebrew..."
+      git clone --depth=1 https://github.com/Homebrew/brew "$HOMEBREW_PREFIX"
+    else
+      log "Homebrew already installed, skipping clone"
+    fi
+
+    export PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:$PATH"
+
+    if [ -n "${HOMEBREW_PACKAGES:-}" ]; then
+      log "Installing packages: $HOMEBREW_PACKAGES"
+      # shellcheck disable=SC2086
+      brew install $HOMEBREW_PACKAGES
+    else
+      log "No packages to install"
+    fi
+
+    log "Homebrew initialization complete"
+  init-skills.sh: |
+    log() { echo "[$(date -Iseconds)] [init-skills] $*"; }
+
+    log "Starting skills initialization"
+
+    # ============================================================
+    # Runtime Dependencies
+    # ============================================================
+    # Some skills require additional runtimes (Python, Go, etc.)
+    # Install them here so they persist across pod restarts.
+    #
+    # Example: Install uv (Python package manager) for Python skills
+    # mkdir -p /home/node/.openclaw/bin
+    # if [ ! -f /home/node/.openclaw/bin/uv ]; then
+    #   log "Installing uv..."
+    #   curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/home/node/.openclaw/bin sh
+    # fi
+    #
+    # Example: Install pnpm and packages for interfaces (e.g., MS Teams)
+    # The read-only filesystem and non-root UID prevent writing to default
+    # pnpm paths (/usr/local/lib/node_modules, ~/.local/share/pnpm, etc.).
+    # Redirect PNPM_HOME to the PVC so the binary persists across restarts.
+    # The init container's HOME=/tmp ensures pnpm's cache, state, and config
+    # writes land on /tmp (writable emptyDir). The store goes on the PVC so
+    # hardlinks work (same filesystem as node_modules) and persist.
+    # PNPM_HOME=/home/node/.openclaw/pnpm
+    # mkdir -p "$PNPM_HOME"
+    # if [ ! -f "$PNPM_HOME/pnpm" ]; then
+    #   log "Installing pnpm..."
+    #   curl -fsSL https://get.pnpm.io/install.sh | env PNPM_HOME="$PNPM_HOME" SHELL=/bin/sh sh -
+    # fi
+    # export PATH="$PNPM_HOME:$PATH"
+    # log "Installing interface dependencies..."
+    # cd /home/node/.openclaw
+    # pnpm install <your-package> --store-dir /home/node/.openclaw/.pnpm-store
+
+    # ============================================================
+    # Skill Installation
+    # ============================================================
+    # Installs skills listed in SKILLS_TO_INSTALL (set via the top-level skills: [] value).
+    # Set skills: [] in your values to skip skill installation entirely.
+    mkdir -p /home/node/.openclaw/workspace/skills
+    cd /home/node/.openclaw/workspace
+    install_skill() {
+      skill="$1"
+      SKILL_NAME="$(basename "$skill")"
+      if [ -z "$skill" ]; then
+        return 0
+      fi
+      if [ -d "skills/$SKILL_NAME" ]; then
+        log "Skill already installed: $skill"
+        return 0
+      fi
+      log "Installing skill: $skill"
+      attempts=6
+      delay=5
+      for i in $(seq 1 "$attempts"); do
+        if npx -y clawhub install "$skill" --no-input; then
+          log "Installed skill: $skill"
+          return 0
+        fi
+        # Add a little jitter so concurrent pods don't retry in lockstep.
+        jitter=$((RANDOM % 5))
+        if [ "$i" -lt "$attempts" ]; then
+          log "WARNING: Failed to install skill: $skill (attempt $i/$attempts). Retrying in $((delay + jitter))s..."
+          sleep $((delay + jitter))
+          delay=$((delay * 2))
+        fi
+      done
+      log "WARNING: Failed to install skill after $attempts attempts: $skill"
+      return 1
+    }
+    for skill in $SKILLS_TO_INSTALL; do
+      install_skill "$skill" || true
+    done
+    log "Skills initialization complete"
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+spec:
+  revisionHistoryLimit: 3
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/name: openclaw
+      app.kubernetes.io/instance: openclaw
+  template:
+    metadata:
+      annotations:
+        checksum/configMaps: d16ed3f007089c9b430a7bb2625a0fdb11ebc19f5fb8851a1c837f21deaa47e9
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: openclaw
+        app.kubernetes.io/name: openclaw
+    spec:
+      enableServiceLinks: false
+      serviceAccountName: default
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - sh
+            - /scripts/init-config.sh
+          env:
+            - name: CONFIG_MODE
+              value: merge
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          name: init-config
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /config
+              name: config
+              readOnly: true
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /scripts
+              name: scripts
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+        - command:
+            - sh
+            - /scripts/init-homebrew.sh
+          env:
+            - name: HOME
+              value: /tmp
+            - name: HOMEBREW_ENABLED
+              value: "false"
+            - name: HOMEBREW_PACKAGES
+              value: ""
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          name: init-homebrew
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /scripts
+              name: scripts
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+        - command:
+            - sh
+            - /scripts/init-skills.sh
+          env:
+            - name: HOME
+              value: /tmp
+            - name: NPM_CONFIG_CACHE
+              value: /tmp/.npm
+            - name: SKILLS_TO_INSTALL
+              value: weather gog
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          name: init-skills
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /scripts
+              name: scripts
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+      containers:
+        - env:
+            - name: XDG_CACHE_HOME
+              value: /tmp
+          image: chromedp/headless-shell:147.0.7727.56
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /json/version
+              port: 9222
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: chromium
+          readinessProbe:
+            httpGet:
+              path: /json/version
+              port: 9222
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          startupProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /json/version
+              port: 9222
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+        - args:
+            - gateway
+            - --bind
+            - lan
+            - --port
+            - "18789"
+          command:
+            - node
+            - dist/index.js
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            tcpSocket:
+              port: 18789
+            timeoutSeconds: 5
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            tcpSocket:
+              port: 18789
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          startupProbe:
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            tcpSocket:
+              port: 18789
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /home/node/.bash_aliases
+              name: bash-aliases
+              readOnly: true
+              subPath: bash_aliases
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - configMap:
+            name: openclaw-config
+          name: bash-aliases
+        - configMap:
+            name: openclaw-config
+          name: config
+        - name: data
+          persistentVolumeClaim:
+            claimName: openclaw
+        - configMap:
+            name: openclaw-scripts
+          name: scripts
+        - emptyDir: {}
+          name: tmp
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "5Gi"
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/service: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+spec:
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+  ports:
+    - port: 18789
+      targetPort: 18789
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/name: openclaw

--- a/tests/snapshots/homebrew-with-packages.yaml
+++ b/tests/snapshots/homebrew-with-packages.yaml
@@ -1,0 +1,491 @@
+
+---
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+data:
+  bash_aliases: |
+    alias openclaw='node /app/dist/index.js'
+  openclaw.json: "{\n  // Gateway configuration\n  \"gateway\": {\n    \"port\": 18789,\n    \"mode\": \"local\",\n    // IMPORTANT: trustedProxies uses exact IP matching only\n    // - CIDR notation is NOT supported - list each proxy IP individually\n    // - IPv6 exact addresses may work but are untested\n    // - Recommend single-stack IPv4 deployments for simplicity\n    \"trustedProxies\": [\"10.0.0.1\"]\n  },\n\n  // Browser configuration (Chromium sidecar)\n  \"browser\": {\n    \"enabled\": true,\n    \"defaultProfile\": \"default\",\n    \"profiles\": {\n      \"default\": {\n        \"cdpUrl\": \"http://localhost:9222\",\n        \"color\": \"#4285F4\"\n      }\n    }\n  },\n\n  // Agent configuration\n  \"agents\": {\n    \"defaults\": {\n      \"workspace\": \"/home/node/.openclaw/workspace\",\n      \"model\": {\n        // Uses ANTHROPIC_API_KEY from environment\n        \"primary\": \"anthropic/claude-opus-4-6\"\n      },\n      \"userTimezone\": \"UTC\",\n      \"timeoutSeconds\": 600,\n      \"maxConcurrent\": 1\n    },\n    \"list\": [\n      {\n        \"id\": \"main\",\n        \"default\": true,\n        \"identity\": {\n          \"name\": \"OpenClaw\",\n          \"emoji\": \"\U0001F99E\"\n        }\n      }\n    ]\n  },\n\n  // Session management\n  \"session\": {\n    \"scope\": \"per-sender\",\n    \"store\": \"/home/node/.openclaw/sessions\",\n    \"reset\": {\n      \"mode\": \"idle\",\n      \"idleMinutes\": 60\n    }\n  },\n\n  // Logging\n  \"logging\": {\n    \"level\": \"info\",\n    \"consoleLevel\": \"info\",\n    \"consoleStyle\": \"compact\",\n    \"redactSensitive\": \"tools\"\n  },\n\n  // Tools configuration\n  \"tools\": {\n    \"profile\": \"full\",\n    \"web\": {\n      \"search\": {\n        \"enabled\": false\n      },\n      \"fetch\": {\n        \"enabled\": true\n      }\n    }\n  }\n\n  // Channel configuration can be added here:\n  // \"channels\": {\n  //   \"telegram\": {\n  //     \"botToken\": \"${TELEGRAM_BOT_TOKEN}\",\n  //     \"enabled\": true\n  //   },\n  //   \"discord\": {\n  //     \"token\": \"${DISCORD_BOT_TOKEN}\"\n  //   },\n  //   \"slack\": {\n  //     \"botToken\": \"${SLACK_BOT_TOKEN}\",\n  //     \"appToken\": \"${SLACK_APP_TOKEN}\"\n  //   }\n  // }\n}\n"
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-scripts
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+data:
+  init-config.sh: |
+    log() { echo "[$(date -Iseconds)] [init-config] $*"; }
+
+    log "Starting config initialization"
+    mkdir -p /home/node/.openclaw
+    CONFIG_MODE="${CONFIG_MODE:-merge}"
+
+    if [ "$CONFIG_MODE" = "merge" ] && [ -f /home/node/.openclaw/openclaw.json ]; then
+      log "Mode: merge - merging Helm config with existing config"
+      if node -e "
+        const fs = require('fs');
+        // Strip JSON5 single-line comments while preserving // inside strings (e.g. URLs)
+        const stripComments = (s) => {
+          let r = '', q = false, i = 0;
+          while (i < s.length) {
+            if (q) {
+              if (s[i] === '\\\\') { r += s[i] + s[i+1]; i += 2; continue; }
+              if (s[i] === '\"') q = false;
+              r += s[i++];
+            } else if (s[i] === '\"') {
+              q = true; r += s[i++];
+            } else if (s[i] === '/' && s[i+1] === '/') {
+              while (i < s.length && s[i] !== '\n') i++;
+            } else { r += s[i++]; }
+          }
+          return r;
+        };
+        let existing;
+        try {
+          existing = JSON.parse(stripComments(fs.readFileSync('/home/node/.openclaw/openclaw.json', 'utf8')));
+        } catch (e) {
+          console.error('[init-config] Warning: existing config is not valid JSON, will overwrite');
+          process.exit(1);
+        }
+        const helm = JSON.parse(stripComments(fs.readFileSync('/config/openclaw.json', 'utf8')));
+        const deepMerge = (target, source) => {
+          for (const key of Object.keys(source)) {
+            if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+              target[key] = target[key] || {};
+              deepMerge(target[key], source[key]);
+            } else {
+              target[key] = source[key];
+            }
+          }
+          return target;
+        };
+        const merged = deepMerge(existing, helm);
+        fs.writeFileSync('/home/node/.openclaw/openclaw.json', JSON.stringify(merged, null, 2));
+      "; then
+        log "Config merged successfully"
+      else
+        log "WARNING: Merge failed (existing config may not be valid JSON), falling back to overwrite"
+        cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+      fi
+    else
+      if [ ! -f /home/node/.openclaw/openclaw.json ]; then
+        log "Fresh install - writing initial config"
+      else
+        log "Mode: overwrite - replacing config with Helm values"
+      fi
+      cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+    fi
+    log "Config initialization complete"
+  init-homebrew.sh: |
+    log() { echo "[$(date -Iseconds)] [init-homebrew] $*"; }
+
+    if [ "${HOMEBREW_ENABLED:-false}" != "true" ]; then
+      log "Homebrew disabled, skipping"
+      exit 0
+    fi
+
+    log "Starting Homebrew initialization"
+
+    HOMEBREW_PREFIX=/home/node/.openclaw/homebrew
+    export HOMEBREW_NO_AUTO_UPDATE=1
+    export HOMEBREW_NO_ANALYTICS=1
+    export HOMEBREW_NO_ENV_HINTS=1
+
+    if [ ! -d "$HOMEBREW_PREFIX" ]; then
+      log "Installing Homebrew..."
+      git clone --depth=1 https://github.com/Homebrew/brew "$HOMEBREW_PREFIX"
+    else
+      log "Homebrew already installed, skipping clone"
+    fi
+
+    export PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:$PATH"
+
+    if [ -n "${HOMEBREW_PACKAGES:-}" ]; then
+      log "Installing packages: $HOMEBREW_PACKAGES"
+      # shellcheck disable=SC2086
+      brew install $HOMEBREW_PACKAGES
+    else
+      log "No packages to install"
+    fi
+
+    log "Homebrew initialization complete"
+  init-skills.sh: |
+    log() { echo "[$(date -Iseconds)] [init-skills] $*"; }
+
+    log "Starting skills initialization"
+
+    # ============================================================
+    # Runtime Dependencies
+    # ============================================================
+    # Some skills require additional runtimes (Python, Go, etc.)
+    # Install them here so they persist across pod restarts.
+    #
+    # Example: Install uv (Python package manager) for Python skills
+    # mkdir -p /home/node/.openclaw/bin
+    # if [ ! -f /home/node/.openclaw/bin/uv ]; then
+    #   log "Installing uv..."
+    #   curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/home/node/.openclaw/bin sh
+    # fi
+    #
+    # Example: Install pnpm and packages for interfaces (e.g., MS Teams)
+    # The read-only filesystem and non-root UID prevent writing to default
+    # pnpm paths (/usr/local/lib/node_modules, ~/.local/share/pnpm, etc.).
+    # Redirect PNPM_HOME to the PVC so the binary persists across restarts.
+    # The init container's HOME=/tmp ensures pnpm's cache, state, and config
+    # writes land on /tmp (writable emptyDir). The store goes on the PVC so
+    # hardlinks work (same filesystem as node_modules) and persist.
+    # PNPM_HOME=/home/node/.openclaw/pnpm
+    # mkdir -p "$PNPM_HOME"
+    # if [ ! -f "$PNPM_HOME/pnpm" ]; then
+    #   log "Installing pnpm..."
+    #   curl -fsSL https://get.pnpm.io/install.sh | env PNPM_HOME="$PNPM_HOME" SHELL=/bin/sh sh -
+    # fi
+    # export PATH="$PNPM_HOME:$PATH"
+    # log "Installing interface dependencies..."
+    # cd /home/node/.openclaw
+    # pnpm install <your-package> --store-dir /home/node/.openclaw/.pnpm-store
+
+    # ============================================================
+    # Skill Installation
+    # ============================================================
+    # Installs skills listed in SKILLS_TO_INSTALL (set via the top-level skills: [] value).
+    # Set skills: [] in your values to skip skill installation entirely.
+    mkdir -p /home/node/.openclaw/workspace/skills
+    cd /home/node/.openclaw/workspace
+    install_skill() {
+      skill="$1"
+      SKILL_NAME="$(basename "$skill")"
+      if [ -z "$skill" ]; then
+        return 0
+      fi
+      if [ -d "skills/$SKILL_NAME" ]; then
+        log "Skill already installed: $skill"
+        return 0
+      fi
+      log "Installing skill: $skill"
+      attempts=6
+      delay=5
+      for i in $(seq 1 "$attempts"); do
+        if npx -y clawhub install "$skill" --no-input; then
+          log "Installed skill: $skill"
+          return 0
+        fi
+        # Add a little jitter so concurrent pods don't retry in lockstep.
+        jitter=$((RANDOM % 5))
+        if [ "$i" -lt "$attempts" ]; then
+          log "WARNING: Failed to install skill: $skill (attempt $i/$attempts). Retrying in $((delay + jitter))s..."
+          sleep $((delay + jitter))
+          delay=$((delay * 2))
+        fi
+      done
+      log "WARNING: Failed to install skill after $attempts attempts: $skill"
+      return 1
+    }
+    for skill in $SKILLS_TO_INSTALL; do
+      install_skill "$skill" || true
+    done
+    log "Skills initialization complete"
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+spec:
+  revisionHistoryLimit: 3
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/controller: main
+      app.kubernetes.io/name: openclaw
+      app.kubernetes.io/instance: openclaw
+  template:
+    metadata:
+      annotations:
+        checksum/configMaps: d16ed3f007089c9b430a7bb2625a0fdb11ebc19f5fb8851a1c837f21deaa47e9
+      labels:
+        app.kubernetes.io/controller: main
+        app.kubernetes.io/instance: openclaw
+        app.kubernetes.io/name: openclaw
+    spec:
+      enableServiceLinks: false
+      serviceAccountName: default
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - sh
+            - /scripts/init-config.sh
+          env:
+            - name: CONFIG_MODE
+              value: merge
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          name: init-config
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /config
+              name: config
+              readOnly: true
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /scripts
+              name: scripts
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+        - command:
+            - sh
+            - /scripts/init-homebrew.sh
+          env:
+            - name: HOME
+              value: /tmp
+            - name: HOMEBREW_ENABLED
+              value: "true"
+            - name: HOMEBREW_PACKAGES
+              value: gh gogcli
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          name: init-homebrew
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /scripts
+              name: scripts
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+        - command:
+            - sh
+            - /scripts/init-skills.sh
+          env:
+            - name: HOME
+              value: /tmp
+            - name: NPM_CONFIG_CACHE
+              value: /tmp/.npm
+            - name: SKILLS_TO_INSTALL
+              value: weather gog
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          name: init-skills
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /scripts
+              name: scripts
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+      containers:
+        - env:
+            - name: XDG_CACHE_HOME
+              value: /tmp
+          image: chromedp/headless-shell:147.0.7727.56
+          livenessProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /json/version
+              port: 9222
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          name: chromium
+          readinessProbe:
+            httpGet:
+              path: /json/version
+              port: 9222
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          startupProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /json/version
+              port: 9222
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+        - args:
+            - gateway
+            - --bind
+            - lan
+            - --port
+            - "18789"
+          command:
+            - node
+            - dist/index.js
+          image: ghcr.io/openclaw/openclaw:APP_VERSION
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            tcpSocket:
+              port: 18789
+            timeoutSeconds: 5
+          name: main
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            tcpSocket:
+              port: 18789
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          startupProbe:
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            tcpSocket:
+              port: 18789
+            timeoutSeconds: 5
+          volumeMounts:
+            - mountPath: /home/node/.bash_aliases
+              name: bash-aliases
+              readOnly: true
+              subPath: bash_aliases
+            - mountPath: /home/node/.openclaw
+              name: data
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - configMap:
+            name: openclaw-config
+          name: bash-aliases
+        - configMap:
+            name: openclaw-config
+          name: config
+        - name: data
+          persistentVolumeClaim:
+            claimName: openclaw
+        - configMap:
+            name: openclaw-scripts
+          name: scripts
+        - emptyDir: {}
+          name: tmp
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "5Gi"
+# Source: openclaw/charts/app-template/templates/common.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/service: openclaw
+    helm.sh/chart: app-template-4.6.2
+  namespace: default
+spec:
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+  ports:
+    - port: 18789
+      targetPort: 18789
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: openclaw
+    app.kubernetes.io/name: openclaw

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$SCRIPT_DIR/../charts/openclaw"
+SNAPSHOT_DIR="$SCRIPT_DIR/snapshots"
+UPDATE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --update | -u) UPDATE=true ;;
+  esac
+done
+
+# Ensure chart dependencies are available
+helm dependency build "$CHART_DIR" --skip-refresh 2>/dev/null \
+  || helm dependency update "$CHART_DIR"
+
+# Read versions from Chart.yaml for normalization (so snapshots don't break on bumps)
+CHART_VERSION=$(grep '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}')
+APP_VERSION=$(grep '^appVersion:' "$CHART_DIR/Chart.yaml" | awk '{print $2}' | tr -d '"')
+
+FAIL=false
+
+run_scenario() {
+  local name="$1"
+  shift
+  local snapshot="$SNAPSHOT_DIR/$name.yaml"
+
+  echo "==> scenario: $name"
+
+  local raw
+  raw=$(helm template openclaw "$CHART_DIR" "$@")
+
+  # Validate and sort: yq exits non-zero on invalid YAML; collect all docs into an array,
+  # sort by kind then name, and emit each document — yq re-serializes consistently.
+  local output
+  if ! output=$(echo "$raw" | yq eval-all '[.] | sort_by(.kind, .metadata.name) | .[]'); then
+    echo "    FAIL: output is not valid YAML"
+    FAIL=true
+    return
+  fi
+  echo "    OK:   YAML valid"
+
+  # Replace chart/app versions with fixed placeholders so snapshots survive version bumps.
+  # Dots are escaped so they are treated as literals in the sed regex.
+  local chart_ver_re="${CHART_VERSION//./\\.}"
+  local app_ver_re="${APP_VERSION//./\\.}"
+  output=$(printf '%s\n' "$output" | sed "s/${chart_ver_re}/CHART_VERSION/g; s/${app_ver_re}/APP_VERSION/g")
+
+  if $UPDATE; then
+    mkdir -p "$SNAPSHOT_DIR"
+    printf '%s\n' "$output" > "$snapshot"
+    echo "    snapshot updated: $snapshot"
+  elif [[ ! -f "$snapshot" ]]; then
+    echo "    FAIL: no snapshot found — run with --update to create it"
+    FAIL=true
+  else
+    if diff --unified=3 "$snapshot" <(printf '%s\n' "$output"); then
+      echo "    OK:   Output matches snapshot"
+    else
+      echo "    FAIL: Output differs from snapshot — run with --update to accept changes"
+      FAIL=true
+    fi
+  fi
+}
+
+run_scenario "default"
+
+run_scenario "homebrew-with-packages" \
+  --set 'app-template.homebrew.enabled=true' \
+  --set 'app-template.homebrew.packages={gh,gogcli}'
+
+echo ""
+if $FAIL; then
+  echo "FAILED: one or more scenarios did not match their snapshots."
+  exit 1
+else
+  echo "All scenarios passed."
+fi


### PR DESCRIPTION
Added optional Homebrew init container with `homebrew.enabled` and allow installation of packages with `homebrew.packages` values.
Disabled by default to be backwards compatible.
When enabled, clones Homebrew into the data PVC and installs the listed packages idempotently before skill installation runs.

Why? - Skills often need cli tools that can be installed and updated easily with homebrew. Homebrew also gives openclaw the ability to install tools that it needs at runtime which is nice.

Not in scope: Keeping homebrew and packages up to date. - This can be easily done with an openclaw cronjob if needed