### PR TITLE
docs(cost-guardrails): add Cost Guardrails section and cost-conscious starter overlay

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openclaw
 description: Helm chart for deploying OpenClaw on Kubernetes — an AI assistant that connects to messaging platforms and executes tasks autonomously.
 type: application
-version: 1.5.21
+version: 1.5.22
 appVersion: "2026.4.15"
 kubeVersion: ">=1.26.0-0"
 icon: https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text.png
@@ -25,8 +25,8 @@ annotations:
     fingerprint: 663862EB60C50E04AD73F198CA0FB121610B01FF
     url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x663862EB60C50E04AD73F198CA0FB121610B01FF
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Bump OpenClaw to 2026.4.15"
+    - kind: added
+      description: "Cost Guardrails section in README and examples/values-cost-conscious.yaml starter overlay"
   artifacthub.io/images: |
     - name: openclaw
       image: ghcr.io/openclaw/openclaw:2026.4.15

--- a/charts/openclaw/README.md
+++ b/charts/openclaw/README.md
@@ -134,6 +134,54 @@ kubectl delete pvc -n openclaw -l app.kubernetes.io/name=openclaw  # optional: r
 
 ---
 
+## Cost Guardrails
+
+OpenClaw sessions can accumulate unbounded LLM cost, especially with
+long-horizon agents (SWE, research, tool-heavy workflows). The default
+configuration in this chart uses `anthropic/claude-opus-4-6` and has no
+per-session budget — a single runaway session can burn hundreds of dollars
+of tokens before `session.reset.idleMinutes` fires.
+
+### Today's knobs (available now)
+
+The chart exposes these existing cost-related knobs:
+
+| Where | Key | Recommended starting value | Why |
+|---|---|---|---|
+| `openclaw.json` → `agents.defaults.timeoutSeconds` | integer | `300` (5 min) | Caps a single agent iteration; default is `600`. |
+| `openclaw.json` → `agents.defaults.maxConcurrent` | integer | `1` | Already the default — keep it at 1 unless you know why. |
+| `openclaw.json` → `session.reset.idleMinutes` | integer | `30` | Faster idle reclaim reduces context accumulation; default is `60`. |
+| `openclaw.json` → `agents.defaults.model.primary` | string | `anthropic/claude-haiku-4-5` for low-stakes workloads | Haiku is ~10× cheaper than Opus for comparable short-task quality. |
+| `openclaw.json` → `tools.web.search.enabled` | boolean | `false` unless needed | Web search triggers both tool-call and follow-up LLM cost. |
+
+See [`examples/values-cost-conscious.yaml`](examples/values-cost-conscious.yaml)
+for a starter overlay that applies all of the above.
+
+### Upcoming: per-session budgets
+
+[openclaw/openclaw#64463](https://github.com/openclaw/openclaw/issues/64463)
+tracks the addition of explicit per-session budgets to the OpenClaw runtime:
+
+- `session.maxTokensPerSession` — hard cap on cumulative input+output tokens
+- `session.maxDurationMinutes` — hard cap on wall-clock duration
+- `session.maxToolCallsPerSession` — hard cap on tool invocations
+- `session.onBudgetExceed` — `stop` | `warn` | `compact`
+
+Once that feature lands upstream and a chart-compatible OpenClaw version is
+released, this chart will gain a documented example and schema entries for
+those fields. For now, track the issue and plan your deployments to opt in.
+
+### External proxy approach
+
+If you need cost routing / fallback / metrics **today**, a common pattern is
+to run [LiteLLM Proxy](https://docs.litellm.ai/) as a **separate** Helm
+release in the same cluster and point OpenClaw at it by setting
+`ANTHROPIC_BASE_URL=http://litellm.<ns>.svc.cluster.local:4000` in your
+`openclaw-env-secret`. This is out of scope for this chart but is the
+simplest operational path until the in-runtime budgets ship.
+
+---
+
 ## Configuration
 
 All values are nested under `app-template:`. See [values.yaml](values.yaml) for full reference.

--- a/charts/openclaw/examples/values-cost-conscious.yaml
+++ b/charts/openclaw/examples/values-cost-conscious.yaml
@@ -1,0 +1,110 @@
+# Cost-conscious starter overlay for the OpenClaw Helm chart.
+#
+# Usage:
+#   helm install openclaw openclaw/openclaw \
+#     -f charts/openclaw/examples/values-cost-conscious.yaml \
+#     -n openclaw
+#
+# This overlay applies the knobs documented in README.md → "Cost Guardrails":
+#
+#   - Uses Haiku as the default model (~10× cheaper than Opus for short tasks)
+#   - Caps a single agent iteration to 5 minutes
+#   - Reclaims idle sessions after 30 minutes
+#   - Disables web search by default (enable per-skill when needed)
+#
+# Suitable starting point for:
+#   - Self-hosted hobby / prosumer deployments
+#   - Small-team deployments where runaway cost risk > model quality sensitivity
+#   - Staging / evaluation environments before committing to a production model
+#
+# NOT a replacement for per-session token budgets (tracked in
+# openclaw/openclaw#64463). When that feature ships, this file will gain
+# `session.maxTokensPerSession` and related fields.
+
+app-template:
+  configMaps:
+    config:
+      data:
+        openclaw.json: |
+          {
+            "gateway": {
+              "port": 18789,
+              "mode": "local",
+              "trustedProxies": ["10.0.0.1"]
+            },
+
+            "browser": {
+              "enabled": true,
+              "defaultProfile": "default",
+              "profiles": {
+                "default": {
+                  "cdpUrl": "http://localhost:9222",
+                  "color": "#4285F4"
+                }
+              }
+            },
+
+            "agents": {
+              "defaults": {
+                "workspace": "/home/node/.openclaw/workspace",
+                "model": {
+                  // Haiku is ~10× cheaper than Opus for short-task quality.
+                  // Override per-agent below if a specific agent needs Opus.
+                  "primary": "anthropic/claude-haiku-4-5"
+                },
+                "userTimezone": "UTC",
+                // Caps a single agent iteration to 5 minutes.
+                // Default is 600 (10 min); long-horizon agents often hit this.
+                "timeoutSeconds": 300,
+                "maxConcurrent": 1
+              },
+              "list": [
+                {
+                  "id": "main",
+                  "default": true,
+                  "identity": {
+                    "name": "OpenClaw",
+                    "emoji": "🦞"
+                  }
+                }
+              ]
+            },
+
+            "session": {
+              "scope": "per-sender",
+              "store": "/home/node/.openclaw/sessions",
+              "reset": {
+                "mode": "idle",
+                // Faster idle reclaim reduces context accumulation.
+                // Default is 60.
+                "idleMinutes": 30
+              }
+
+              // TODO: Once openclaw/openclaw#64463 ships, uncomment:
+              // ,"maxTokensPerSession": 500000
+              // ,"maxDurationMinutes": 120
+              // ,"maxToolCallsPerSession": 30
+              // ,"onBudgetExceed": "stop"
+            },
+
+            "logging": {
+              "level": "info",
+              "consoleLevel": "info",
+              "consoleStyle": "compact",
+              "redactSensitive": "tools"
+            },
+
+            "tools": {
+              "profile": "full",
+              "web": {
+                "search": {
+                  // Web search triggers tool-call + follow-up LLM cost.
+                  // Enable only if your workflow requires it.
+                  "enabled": false
+                },
+                "fetch": {
+                  "enabled": true
+                }
+              }
+            }
+          }


### PR DESCRIPTION
## Summary

Adds operator-facing documentation and a starter values overlay for cost
control using only knobs that exist in the chart today. No behavior change
for existing users.

## Motivation

OpenClaw's default config (`anthropic/claude-opus-4-6`, `timeoutSeconds:
600`, `idleMinutes: 60`, web search available) is reasonable for
exploratory / single-user deployments, but it is also the configuration
most likely to produce surprise cost incidents for operators running
long-horizon agents (SWE loops, research pipelines, automated outreach).

The chart already exposes the knobs operators need — but they are
distributed across `openclaw.json` fields, easy to miss, and not
documented as a cost-control concern. This PR centralizes that guidance.

Tracking issue upstream: [openclaw/openclaw#64463](https://github.com/openclaw/openclaw/issues/64463)
for proper per-session token / duration / tool-call budgets in the
runtime. This PR is a docs-only companion that users can apply today
while that upstream feature is in progress.

## Changes

- **`charts/openclaw/README.md`** — new "Cost Guardrails" section between
  Uninstall and Configuration. Documents four existing knobs
  (`agents.defaults.timeoutSeconds`, `session.reset.idleMinutes`,
  `agents.defaults.model.primary`, `tools.web.search.enabled`) with a
  recommended starting value and a one-line rationale for each. Also
  references #64463 and describes the external LiteLLM-as-separate-Helm-
  release pattern for today's operators who need cost routing now.

- **`charts/openclaw/examples/values-cost-conscious.yaml`** — new 110-line
  starter overlay. Applies all four documented knobs. Uses Haiku as the
  default model, caps agent iteration to 5 minutes, reclaims idle
  sessions after 30 minutes, and disables web search. Reserves `TODO`
  placeholders for `session.maxTokensPerSession` /
  `session.maxDurationMinutes` / `session.maxToolCallsPerSession` /
  `session.onBudgetExceed` so users can uncomment once #64463 lands.

- **`charts/openclaw/Chart.yaml`** — patch bump `1.5.21 → 1.5.22` and
  updated `artifacthub.io/changes` annotation.

## Test plan

- [x] `helm lint charts/openclaw` — passes
- [x] `helm template test charts/openclaw` — still renders the full
  resource set (2 ConfigMap + Deployment + PVC + Service)
- [x] Embedded `openclaw.json` in the starter overlay parses correctly
  under the chart's own `init-config.sh` JSON5 comment stripper logic
- [x] YAML well-formed (`python3 -c "import yaml; yaml.safe_load(open(...))"`)

## Not in this PR

- Adding structured chart values for session budget fields — should follow
  after #64463 lands in a released OpenClaw version, so `appVersion` can
  be bumped in lockstep.
- LiteLLM-as-sidecar co-deployment — larger chart change, tracked as a
  separate discussion; the README section intentionally recommends the
  external-release path today because it requires zero chart changes.

## Checklist

- [x] Patch version bump (no schema / behavior change)
- [x] `artifacthub.io/changes` annotation updated
- [x] No values.yaml schema comments added (no schema regeneration needed)
- [x] No breaking changes